### PR TITLE
[#33] Feat: 애플 캘린더 원본 이벤트/ 애플캘린더 연동,설정 / 애플 캘린더 매핑 / 서버->ios 작업 쓰기 큐 엔티티 생성

### DIFF
--- a/src/main/java/app/tamingo/domain/calendar/entity/CalendarEvent.java
+++ b/src/main/java/app/tamingo/domain/calendar/entity/CalendarEvent.java
@@ -1,0 +1,165 @@
+package app.tamingo.domain.calendar.entity;
+
+import app.tamingo.BaseEntity;
+import app.tamingo.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "calendar_event",
+        indexes = {
+                @Index(name = "idx_calendar_event_user_id", columnList = "user_id"),
+                @Index(name = "idx_calendar_event_integration_id", columnList = "integration_id"),
+                @Index(name = "idx_calendar_event_external_uid", columnList = "external_event_uid")
+        }
+)
+public class CalendarEvent extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 애플캘린더 연동 외래키
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "integration_id", nullable = false)
+    private CalendarIntegration integration;
+
+    // 유저 외래키
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // 캘린더 제공자 (APPLE)
+    @Column(name = "provider", nullable = false, length = 30)
+    private String provider;
+
+    // 외부 이벤트 UID
+    @Column(name = "external_event_uid", nullable = false, length = 255)
+    private String externalEventUid;
+
+    // 외부 캘린더 ID
+    @Column(name = "calendar_external_id", length = 255)
+    private String calendarExternalId;
+
+    // 캘린더 이름
+    @Column(name = "calendar_name", length = 255)
+    private String calendarName;
+
+    // 일정 제목
+    @Column(name = "title", length = 255)
+    private String title;
+
+    // 시작 시각
+    @Column(name = "start_at", nullable = false)
+    private LocalDateTime startAt;
+
+    // 종료 시각
+    @Column(name = "end_at", nullable = false)
+    private LocalDateTime endAt;
+
+    // 종일 일정 여부
+    @Column(name = "is_all_day", nullable = false)
+    private boolean isAllDay;
+
+    // 타임존
+    @Column(name = "timezone", length = 50)
+    private String timezone;
+
+    // 장소
+    @Column(name = "location", length = 255)
+    private String location;
+
+    // 메모
+    @Lob
+    @Column(name = "notes")
+    private String notes;
+
+    // 외부 마지막 수정 시각
+    @Column(name = "last_external_modified_at")
+    private LocalDateTime lastExternalModifiedAt;
+
+    // 삭제 시각 (소프트 딜리트)
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public boolean isDeleted() {
+        return deletedAt != null;
+    }
+
+    public void delete() {
+        if (this.deletedAt != null) return;
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    @Builder(builderMethodName = "internalBuilder")
+    private CalendarEvent(
+            CalendarIntegration integration,
+            User user,
+            String provider,
+            String externalEventUid,
+            String calendarExternalId,
+            String calendarName,
+            String title,
+            LocalDateTime startAt,
+            LocalDateTime endAt,
+            boolean isAllDay,
+            String timezone,
+            String location,
+            String notes,
+            LocalDateTime lastExternalModifiedAt
+    ) {
+        this.integration = integration;
+        this.user = user;
+        this.provider = provider;
+        this.externalEventUid = externalEventUid;
+        this.calendarExternalId = calendarExternalId;
+        this.calendarName = calendarName;
+        this.title = title;
+        this.startAt = startAt;
+        this.endAt = endAt;
+        this.isAllDay = isAllDay;
+        this.timezone = timezone;
+        this.location = location;
+        this.notes = notes;
+        this.lastExternalModifiedAt = lastExternalModifiedAt;
+    }
+
+    public static CalendarEvent of(
+            CalendarIntegration integration,
+            User user,
+            String provider,
+            String externalEventUid,
+            String calendarExternalId,
+            String calendarName,
+            String title,
+            LocalDateTime startAt,
+            LocalDateTime endAt,
+            boolean isAllDay,
+            String timezone,
+            String location,
+            String notes,
+            LocalDateTime lastExternalModifiedAt
+    ) {
+        return CalendarEvent.internalBuilder()
+                .integration(integration)
+                .user(user)
+                .provider(provider)
+                .externalEventUid(externalEventUid)
+                .calendarExternalId(calendarExternalId)
+                .calendarName(calendarName)
+                .title(title)
+                .startAt(startAt)
+                .endAt(endAt)
+                .isAllDay(isAllDay)
+                .timezone(timezone)
+                .location(location)
+                .notes(notes)
+                .lastExternalModifiedAt(lastExternalModifiedAt)
+                .build();
+    }
+}

--- a/src/main/java/app/tamingo/domain/calendar/entity/CalendarIntegration.java
+++ b/src/main/java/app/tamingo/domain/calendar/entity/CalendarIntegration.java
@@ -1,0 +1,113 @@
+package app.tamingo.domain.calendar.entity;
+
+import app.tamingo.BaseEntity;
+import app.tamingo.domain.calendar.enums.CalendarIntegrationStatus;
+import app.tamingo.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "calendar_integration",
+        indexes = {
+                @Index(name = "idx_calendar_integration_user_id", columnList = "user_id")
+        }
+)
+public class CalendarIntegration extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 유저 외래키
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // 연동 제공자 (APPLE)
+    @Column(name = "provider", nullable = false, length = 30)
+    private String provider;
+
+    // Apple -> App 동기화 여부
+    @Column(name = "sync_from_apple", nullable = false)
+    private boolean syncFromApple;
+
+    // App -> Apple 동기화 여부
+    @Column(name = "sync_to_apple", nullable = false)
+    private boolean syncToApple;
+
+    // 연동 상태
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 30)
+    private CalendarIntegrationStatus status;
+
+    // 마지막 동기화 성공 시간
+    @Column(name = "last_synced_at")
+    private LocalDateTime lastSyncedAt;
+
+    @Builder(builderMethodName = "internalBuilder")
+    private CalendarIntegration(
+            User user,
+            String provider,
+            boolean syncFromApple,
+            boolean syncToApple,
+            CalendarIntegrationStatus status,
+            LocalDateTime lastSyncedAt
+    ) {
+        this.user = user;
+        this.provider = provider;
+        this.syncFromApple = syncFromApple;
+        this.syncToApple = syncToApple;
+        this.status = status;
+        this.lastSyncedAt = lastSyncedAt;
+    }
+
+    public static CalendarIntegration of(
+            User user,
+            String provider,
+            boolean syncFromApple,
+            boolean syncToApple,
+            CalendarIntegrationStatus status,
+            LocalDateTime lastSyncedAt
+    ) {
+        return CalendarIntegration.internalBuilder()
+                .user(user)
+                .provider(provider)
+                .syncFromApple(syncFromApple)
+                .syncToApple(syncToApple)
+                .status(status)
+                .lastSyncedAt(lastSyncedAt)
+                .build();
+    }
+
+    // 토글 변경
+    public void updateSyncFlags(boolean syncFromApple, boolean syncToApple) {
+        this.syncFromApple = syncFromApple;
+        this.syncToApple = syncToApple;
+    }
+
+    // 상태 변경
+    public void updateStatus(CalendarIntegrationStatus status) {
+        this.status = status;
+    }
+
+    // 동기화 성공 처리
+    public void markSyncedNow() {
+        this.lastSyncedAt = LocalDateTime.now();
+        this.status = CalendarIntegrationStatus.ACTIVE;
+    }
+
+    // 동기화 시작 처리
+    public void markSyncing() {
+        this.status = CalendarIntegrationStatus.SYNCING;
+    }
+
+    // 오류 처리
+    public void markError() {
+        this.status = CalendarIntegrationStatus.ERROR;
+    }
+}

--- a/src/main/java/app/tamingo/domain/calendar/entity/CalendarOutbox.java
+++ b/src/main/java/app/tamingo/domain/calendar/entity/CalendarOutbox.java
@@ -1,0 +1,164 @@
+package app.tamingo.domain.calendar.entity;
+
+import app.tamingo.BaseEntity;
+import app.tamingo.domain.calendar.enums.OutboxOpType;
+import app.tamingo.domain.calendar.enums.OutboxStatus;
+import app.tamingo.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "calendar_outbox",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_calendar_outbox_integration_idempotency",
+                        columnNames = {"integration_id", "idempotency_key"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_calendar_outbox_user_id", columnList = "user_id"),
+                @Index(name = "idx_calendar_outbox_integration_id", columnList = "integration_id"),
+                @Index(name = "idx_calendar_outbox_status_createdAt", columnList = "status, createdAt"),
+                @Index(name = "idx_calendar_outbox_integration_status", columnList = "integration_id, status")
+        }
+)
+public class CalendarOutbox extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 유저 외래키
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // 애플캘린더 연동 외래키
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "integration_id", nullable = false)
+    private CalendarIntegration integration;
+
+    // 캘린더 이벤트 외래키 (nullable)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "calendar_event_id")
+    private CalendarEvent calendarEvent;
+
+    // 대상 외부 이벤트 UID (nullable)
+    @Column(name = "target_external_event_uid", length = 255)
+    private String targetExternalEventUid;
+
+    // 작업유형
+    @Enumerated(EnumType.STRING)
+    @Column(name = "op_type", nullable = false, length = 30)
+    private OutboxOpType opType;
+
+    // 멱등성 키
+    @Column(name = "idempotency_key", nullable = false, length = 255)
+    private String idempotencyKey;
+
+    // 작업 데이터 (json)
+    @Lob
+    @Column(name = "payload_json", nullable = false, columnDefinition = "jsonb")
+    private String payloadJson;
+
+    // 작업 상태
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 30)
+    private OutboxStatus status;
+
+    // 시도 횟수
+    @Column(name = "attempt_count", nullable = false)
+    private int attemptCount;
+
+    // 마지막 시도 시각
+    @Column(name = "last_attempt_at")
+    private LocalDateTime lastAttemptAt;
+
+    // 처리 완료 시각
+    @Column(name = "processed_at")
+    private LocalDateTime processedAt;
+
+    // 에러 메시지
+    @Column(name = "error_message", length = 1000)
+    private String errorMessage;
+
+    @Builder(builderMethodName = "internalBuilder")
+    private CalendarOutbox(
+            User user,
+            CalendarIntegration integration,
+            CalendarEvent calendarEvent,
+            String targetExternalEventUid,
+            OutboxOpType opType,
+            String idempotencyKey,
+            String payloadJson,
+            OutboxStatus status,
+            int attemptCount,
+            LocalDateTime lastAttemptAt,
+            LocalDateTime processedAt,
+            String errorMessage
+    ) {
+        this.user = user;
+        this.integration = integration;
+        this.calendarEvent = calendarEvent;
+        this.targetExternalEventUid = targetExternalEventUid;
+        this.opType = opType;
+        this.idempotencyKey = idempotencyKey;
+        this.payloadJson = payloadJson;
+        this.status = status;
+        this.attemptCount = attemptCount;
+        this.lastAttemptAt = lastAttemptAt;
+        this.processedAt = processedAt;
+        this.errorMessage = errorMessage;
+    }
+
+    public static CalendarOutbox of(
+            User user,
+            CalendarIntegration integration,
+            CalendarEvent calendarEvent,
+            String targetExternalEventUid,
+            OutboxOpType opType,
+            String idempotencyKey,
+            String payloadJson
+    ) {
+        return CalendarOutbox.internalBuilder()
+                .user(user)
+                .integration(integration)
+                .calendarEvent(calendarEvent)
+                .targetExternalEventUid(targetExternalEventUid)
+                .opType(opType)
+                .idempotencyKey(idempotencyKey)
+                .payloadJson(payloadJson)
+                .status(OutboxStatus.PENDING)
+                .attemptCount(0)
+                .build();
+    }
+
+    // 처리 시작
+    public void markProcessing() {
+        this.status = OutboxStatus.PROCESSING;
+    }
+
+    // 시도 기록
+    public void recordAttempt() {
+        this.attemptCount += 1;
+        this.lastAttemptAt = LocalDateTime.now();
+    }
+
+    // 성공 처리
+    public void markSuccess() {
+        this.status = OutboxStatus.SUCCESS;
+        this.processedAt = LocalDateTime.now();
+        this.errorMessage = null;
+    }
+
+    // 실패 처리
+    public void markFailed(String errorMessage) {
+        this.status = OutboxStatus.FAILED;
+        this.errorMessage = errorMessage;
+    }
+}

--- a/src/main/java/app/tamingo/domain/calendar/entity/ExternalTaskMapping.java
+++ b/src/main/java/app/tamingo/domain/calendar/entity/ExternalTaskMapping.java
@@ -1,0 +1,118 @@
+package app.tamingo.domain.calendar.entity;
+
+import app.tamingo.BaseEntity;
+import app.tamingo.domain.calendar.enums.ConflictStatus;
+import app.tamingo.domain.calendar.enums.LinkStatus;
+import app.tamingo.domain.calendar.enums.SyncDirection;
+import app.tamingo.domain.schedule.entity.Schedule;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "external_task_mapping",
+        indexes = {
+                @Index(name = "idx_ext_mapping_integration_id", columnList = "integration_id"),
+                @Index(name = "idx_ext_mapping_schedule_id", columnList = "schedule_id"),
+                @Index(name = "idx_ext_mapping_calendar_event_id", columnList = "calendar_event_id")
+        }
+)
+public class ExternalTaskMapping extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 애플캘린더 연동 외래키
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "integration_id", nullable = false)
+    private CalendarIntegration integration;
+
+    // 일정 외래키
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "schedule_id", nullable = false)
+    private Schedule schedule;
+
+    // 캘린더 이벤트 외래키
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "calendar_event_id", nullable = false)
+    private CalendarEvent calendarEvent;
+
+    // 연결 상태
+    @Enumerated(EnumType.STRING)
+    @Column(name = "link_status", nullable = false, length = 30)
+    private LinkStatus linkStatus;
+
+    // 동기화 방향
+    @Enumerated(EnumType.STRING)
+    @Column(name = "sync_direction", nullable = false, length = 30)
+    private SyncDirection syncDirection;
+
+    // 충돌 상태
+    @Enumerated(EnumType.STRING)
+    @Column(name = "conflict_status", length = 30)
+    private ConflictStatus conflictStatus;
+
+    // 마지막 동기화 시각
+    @Column(name = "last_synced_at")
+    private LocalDateTime lastSyncedAt;
+
+    @Builder(builderMethodName = "internalBuilder")
+    private ExternalTaskMapping(
+            CalendarIntegration integration,
+            Schedule schedule,
+            CalendarEvent calendarEvent,
+            LinkStatus linkStatus,
+            SyncDirection syncDirection,
+            ConflictStatus conflictStatus,
+            LocalDateTime lastSyncedAt
+    ) {
+        this.integration = integration;
+        this.schedule = schedule;
+        this.calendarEvent = calendarEvent;
+        this.linkStatus = linkStatus;
+        this.syncDirection = syncDirection;
+        this.conflictStatus = conflictStatus;
+        this.lastSyncedAt = lastSyncedAt;
+    }
+
+    public static ExternalTaskMapping of(
+            CalendarIntegration integration,
+            Schedule schedule,
+            CalendarEvent calendarEvent,
+            LinkStatus linkStatus,
+            SyncDirection syncDirection,
+            ConflictStatus conflictStatus,
+            LocalDateTime lastSyncedAt
+    ) {
+        return ExternalTaskMapping.internalBuilder()
+                .integration(integration)
+                .schedule(schedule)
+                .calendarEvent(calendarEvent)
+                .linkStatus(linkStatus)
+                .syncDirection(syncDirection)
+                .conflictStatus(conflictStatus)
+                .lastSyncedAt(lastSyncedAt)
+                .build();
+    }
+
+    // 동기화 성공 처리
+    public void markSyncedNow() {
+        this.lastSyncedAt = LocalDateTime.now();
+        this.conflictStatus = ConflictStatus.NONE;
+    }
+
+    // 충돌 처리
+    public void markConflict() {
+        this.conflictStatus = ConflictStatus.CONFLICT;
+    }
+
+    // 연결 해제 처리
+    public void unlink() {
+        this.linkStatus = LinkStatus.UNLINKED;
+    }
+}

--- a/src/main/java/app/tamingo/domain/calendar/enums/CalendarIntegrationStatus.java
+++ b/src/main/java/app/tamingo/domain/calendar/enums/CalendarIntegrationStatus.java
@@ -1,0 +1,8 @@
+package app.tamingo.domain.calendar.enums;
+
+public enum CalendarIntegrationStatus {
+    ACTIVE,     // 정상 연동됨
+    INACTIVE,   // 사용자가 연동 비활성화
+    SYNCING,    // 동기화 중
+    ERROR       // 동기화 오류
+}

--- a/src/main/java/app/tamingo/domain/calendar/enums/ConflictStatus.java
+++ b/src/main/java/app/tamingo/domain/calendar/enums/ConflictStatus.java
@@ -1,0 +1,7 @@
+package app.tamingo.domain.calendar.enums;
+
+public enum ConflictStatus {
+    NONE,       // 충돌 없음
+    CONFLICT,   // 충돌 발생
+    RESOLVED    // 충돌 해결됨
+}

--- a/src/main/java/app/tamingo/domain/calendar/enums/LinkStatus.java
+++ b/src/main/java/app/tamingo/domain/calendar/enums/LinkStatus.java
@@ -1,0 +1,6 @@
+package app.tamingo.domain.calendar.enums;
+
+public enum LinkStatus {
+    LINKED,     // 매핑 완료(정상 연결)
+    UNLINKED    // 연결 해제(또는 아직 연결 안 됨)
+}

--- a/src/main/java/app/tamingo/domain/calendar/enums/OutboxOpType.java
+++ b/src/main/java/app/tamingo/domain/calendar/enums/OutboxOpType.java
@@ -1,0 +1,7 @@
+package app.tamingo.domain.calendar.enums;
+
+public enum OutboxOpType {
+    CREATE,   // 외부(Apple) 이벤트 생성
+    UPDATE,   // 외부 이벤트 수정
+    DELETE    // 외부 이벤트 삭제
+}

--- a/src/main/java/app/tamingo/domain/calendar/enums/OutboxStatus.java
+++ b/src/main/java/app/tamingo/domain/calendar/enums/OutboxStatus.java
@@ -1,0 +1,8 @@
+package app.tamingo.domain.calendar.enums;
+
+public enum OutboxStatus {
+    PENDING,     // 대기
+    PROCESSING,  // 처리 중
+    SUCCESS,     // 처리 완료
+    FAILED       // 실패(재시도 가능/불가 정책은 attemptCount로)
+}

--- a/src/main/java/app/tamingo/domain/calendar/enums/SyncDirection.java
+++ b/src/main/java/app/tamingo/domain/calendar/enums/SyncDirection.java
@@ -1,0 +1,7 @@
+package app.tamingo.domain.calendar.enums;
+
+public enum SyncDirection {
+    APP_TO_APPLE,   // App -> Apple
+    APPLE_TO_APP    // Apple -> App
+}
+


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->

- 애플 캘린더 관련 엔티티 추가

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #33 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->