### PR TITLE
[#18] Fix: GptClient를 직접 사용하는 방식으로 수정 및 url 수정

### DIFF
--- a/src/main/java/app/tamingo/domain/gpt/client/GptClient.java
+++ b/src/main/java/app/tamingo/domain/gpt/client/GptClient.java
@@ -21,7 +21,7 @@ public class GptClient extends ApiClient {
     public GptResponse requestCompletion(GptRequest request) {
         try {
             return post(
-                    uri -> uri.path("/responses").build(),
+                    uri -> uri.path("/chat/completions").build(),
                     request,
                     GptResponse.class
             );

--- a/src/main/java/app/tamingo/domain/gpt/service/common/GptService.java
+++ b/src/main/java/app/tamingo/domain/gpt/service/common/GptService.java
@@ -2,6 +2,8 @@ package app.tamingo.domain.gpt.service.common;
 
 import app.tamingo.common.exception.CustomException;
 import app.tamingo.common.response.gpt.GptErrorCode;
+import app.tamingo.common.webclient.ApiClient;
+import app.tamingo.domain.gpt.client.GptClient;
 import app.tamingo.domain.gpt.dto.ExampleGptResponse;
 import app.tamingo.domain.gpt.dto.GptRequest;
 import app.tamingo.domain.gpt.dto.GptResponse;
@@ -12,6 +14,7 @@ import app.tamingo.domain.gpt.prompt.common.PromptTemplate;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.models.OpenAPI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,7 +25,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 @RequiredArgsConstructor
 public class GptService {
 
-    private final WebClient webClient;
+    private final GptClient gptClient;
     private final GeneralSystemPrompt generalSystemPrompt = new GeneralSystemPrompt();
 
     public String callGpt(GptRequest gptRequest){
@@ -36,14 +39,7 @@ public class GptService {
         gptRequest.setMaxTokens(maxTokens);
 
         // OpenAi 호출
-        return webClient.post()
-                .uri("/chat/completions")
-                .bodyValue(gptRequest)
-                .retrieve()
-                .bodyToMono(GptResponse.class)
-                .map(GptResponse::firstContent)
-                .block();
-
+        return gptClient.requestCompletion(gptRequest).firstContent();
     }
 
     /**


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
GptClient를 직접 사용하지 않고 WebClient를 사용하는 방식에서, GptClient를 사용해서 호출하는 방식으로 수정했습니다.
GptClient에 responses url로 호출하고 있는 부분을 /chat/completions로 url을 수정해서 정상적으로 호출하도록 수정했습니다.

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #18 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->