### PR TITLE
[Feat] 자주 가는 장소 등록(ai 추론 여부 포함),내 장소 리스트 가져오기 구현

### DIFF
--- a/src/main/java/app/tamingo/domain/favoriteplace/controller/FavoritePlaceController.java
+++ b/src/main/java/app/tamingo/domain/favoriteplace/controller/FavoritePlaceController.java
@@ -4,7 +4,9 @@ import app.tamingo.common.response.ApiResponse;
 import app.tamingo.common.response.SuccessCode;
 import app.tamingo.domain.favoriteplace.dto.FavoritePlaceRequest;
 import app.tamingo.domain.favoriteplace.dto.FavoritePlaceResponse;
+import app.tamingo.domain.favoriteplace.dto.FavoritePlaceSimpleResponse;
 import app.tamingo.domain.favoriteplace.service.FavoritePlaceService;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -52,5 +54,26 @@ public class FavoritePlaceController {
     public ApiResponse<Void> delete(@PathVariable Long placeId) {
         favoritePlaceService.delete(placeId);
         return ApiResponse.onSuccess(null, SuccessCode.NO_CONTENT);
+    }
+
+    // 자주 가는 장소 등록(ai 여부 포함)
+    @Operation(summary = "자주 가는 장소 등록(ai 추론 여부 포함) API",description = "ai 추론 여부 포함")
+    @PostMapping("/ai")
+    public ApiResponse<Long> aiSave(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody @Valid FavoritePlaceRequest.SaveDto request) {
+
+        Long response = favoritePlaceService.aiSave(userId, request);
+        return ApiResponse.onSuccess(response, SuccessCode.CREATED);
+    }
+
+    // 일정,할일에서 자주 가는 장소 목록 조회
+    @Operation(summary = "일정, 할 일 자주 가는 장소 조회 API",description = "일정, 할 일에서 사용")
+    @GetMapping("/simple")
+    public ApiResponse<List<FavoritePlaceSimpleResponse>> findAllSimple(
+            @AuthenticationPrincipal Long userId
+    ) {
+        List<FavoritePlaceSimpleResponse> places = favoritePlaceService.findAllSimple(userId);
+        return ApiResponse.onSuccess(places, SuccessCode.OK);
     }
 }

--- a/src/main/java/app/tamingo/domain/favoriteplace/dto/FavoritePlaceRequest.java
+++ b/src/main/java/app/tamingo/domain/favoriteplace/dto/FavoritePlaceRequest.java
@@ -12,7 +12,8 @@ public class FavoritePlaceRequest {
             String address,
 
             Double latitude,
-            Double longitude
+            Double longitude,
+            boolean isAiSuggested
     ) {}
 
     public record UpdateDto(

--- a/src/main/java/app/tamingo/domain/favoriteplace/dto/FavoritePlaceSimpleResponse.java
+++ b/src/main/java/app/tamingo/domain/favoriteplace/dto/FavoritePlaceSimpleResponse.java
@@ -1,0 +1,21 @@
+package app.tamingo.domain.favoriteplace.dto;
+
+import app.tamingo.domain.favoriteplace.entity.FavoritePlaceStandard;
+
+public record FavoritePlaceSimpleResponse(
+        Long id,
+        String name,
+        String address,
+        Double latitude,
+        Double longitude
+) {
+    public static FavoritePlaceSimpleResponse from(FavoritePlaceStandard entity) {
+        return new FavoritePlaceSimpleResponse(
+                entity.getId(),
+                entity.getName(),
+                entity.getAddress(),
+                entity.getLatitude(),
+                entity.getLongitude()
+        );
+    }
+}

--- a/src/main/java/app/tamingo/domain/favoriteplace/entity/FavoritePlaceStandard.java
+++ b/src/main/java/app/tamingo/domain/favoriteplace/entity/FavoritePlaceStandard.java
@@ -41,13 +41,18 @@ public class FavoritePlaceStandard extends BaseEntity {
     // 장소의 경도
     private Double longitude;
 
+    // AI 추론 장소 여부 (기본값 false)
+    @Column(nullable = false)
+    private boolean isAiSuggested;
+
     @Builder
-    private FavoritePlaceStandard(User user, String name, String address, Double latitude, Double longitude) {
+    private FavoritePlaceStandard(User user, String name, String address, Double latitude, Double longitude,boolean isAiSuggested) {
         this.user = user;
         this.name = name;
         this.address = address;
         this.latitude = latitude;
         this.longitude = longitude;
+        this.isAiSuggested = isAiSuggested;
     }
 
     public static FavoritePlaceStandard of(User user, String name, String address, Double latitude, Double longitude) {
@@ -57,6 +62,7 @@ public class FavoritePlaceStandard extends BaseEntity {
                 .address(address)
                 .latitude(latitude)
                 .longitude(longitude)
+                .isAiSuggested(false)
                 .build();
     }
 
@@ -66,6 +72,20 @@ public class FavoritePlaceStandard extends BaseEntity {
         this.address = address;
         this.latitude = latitude;
         this.longitude = longitude;
+    }
+
+    // AI 여부를 포함하는 생성 메서드
+    public static FavoritePlaceStandard create(
+            User user, String name, String address,
+            Double latitude, Double longitude, boolean isAiSuggested) {
+        return FavoritePlaceStandard.builder()
+                .user(user)
+                .name(name)
+                .address(address)
+                .latitude(latitude)
+                .longitude(longitude)
+                .isAiSuggested(isAiSuggested)
+                .build();
     }
 
 }

--- a/src/main/java/app/tamingo/domain/favoriteplace/service/FavoritePlaceService.java
+++ b/src/main/java/app/tamingo/domain/favoriteplace/service/FavoritePlaceService.java
@@ -3,6 +3,7 @@ package app.tamingo.domain.favoriteplace.service;
 import app.tamingo.common.exception.CustomException;
 import app.tamingo.domain.favoriteplace.dto.FavoritePlaceRequest;
 import app.tamingo.domain.favoriteplace.dto.FavoritePlaceResponse;
+import app.tamingo.domain.favoriteplace.dto.FavoritePlaceSimpleResponse;
 import app.tamingo.domain.favoriteplace.entity.FavoritePlaceStandard;
 import app.tamingo.domain.favoriteplace.exception.FavoritePlaceErrorCode;
 import app.tamingo.domain.favoriteplace.repository.FavoritePlaceRepository;
@@ -131,4 +132,38 @@ public class FavoritePlaceService {
             );
         }
     }
+
+    // ai 추론 포함 저장
+    @Transactional
+    public Long aiSave(Long userId, FavoritePlaceRequest.SaveDto request) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+        if (favoritePlaceRepository.existsByDuplicate(user, request.name(), request.address())) {
+            throw new CustomException(FavoritePlaceErrorCode.FAVORITE_PLACE_ALREADY_EXISTS);
+        }
+
+        FavoritePlaceStandard favoritePlaceStandard = FavoritePlaceStandard.create(
+                user,
+                request.name(),
+                request.address(),
+                request.latitude(),
+                request.longitude(),
+                request.isAiSuggested()
+        );
+
+        return favoritePlaceRepository.save(favoritePlaceStandard).getId();
+    }
+
+    // 일정/할 일에서 선택용 목록 조회
+    public List<FavoritePlaceSimpleResponse> findAllSimple(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+        return favoritePlaceRepository.findAllByUser(user).stream()
+                .map(FavoritePlaceSimpleResponse::from)
+                .toList();
+    }
+
 }

--- a/src/main/java/app/tamingo/domain/onboarding/service/OnboardingService.java
+++ b/src/main/java/app/tamingo/domain/onboarding/service/OnboardingService.java
@@ -114,7 +114,8 @@ public class OnboardingService {
                         p.name(),
                         p.address(),
                         p.latitude(),
-                        p.longitude()
+                        p.longitude(),
+                        false
                 ))
                 .toList();
     }

--- a/src/main/java/app/tamingo/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/app/tamingo/domain/schedule/controller/ScheduleController.java
@@ -6,6 +6,7 @@ import app.tamingo.domain.gpt.service.schedule.AiScheduleService;
 import app.tamingo.domain.schedule.dto.*;
 import app.tamingo.domain.schedule.service.PlaceContextService;
 import app.tamingo.domain.schedule.service.ScheduleService;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -25,6 +26,7 @@ public class ScheduleController {
     private final AiScheduleService aiScheduleService;
 
     // 일정 생성 API
+    @Operation(summary = "일정 생성 API",description = "일정 생성")
     @PostMapping("/create")
     public ApiResponse<CreateScheduleResponse> createSchedule(
             @AuthenticationPrincipal Long userId,
@@ -34,7 +36,8 @@ public class ScheduleController {
         return ApiResponse.onSuccess(response, SuccessCode.OK);
     }
 
-    // 일정 추천 API
+    // 사용자 장소 수정 시 할 일 추천 API
+    @Operation(summary = "사용자 장소 수정 시 할 일 추천 API", description = "사용자가 직접 장소 수정 시 할 일 리스트 추천")
     @PostMapping("/recommend-todos")
     public ApiResponse<RecommendTodoResponse> getRecommendTodos(
             @AuthenticationPrincipal Long userId,
@@ -50,6 +53,7 @@ public class ScheduleController {
     }
 
     // ai 일정 추론 API (제목 -> 장소/할일 추론)
+    @Operation(summary = "제목 기반 AI 일정 추론 API",description = "장소&카테고리&자주 가는 장소 추가 여부")
     @PostMapping("/ai-inference")
     public ApiResponse<AiInferenceResponse> inferSchedule(
             @AuthenticationPrincipal Long userId,
@@ -59,7 +63,8 @@ public class ScheduleController {
         return ApiResponse.onSuccess(response, SuccessCode.OK);
     }
 
-    // 일정 목록 조회 API
+    // 특정 일자 일정 목록 조회 API
+    @Operation(summary = "특정 일자 일정 목록 API", description = "yyyy-mm-dd 형태로 조회")
     @GetMapping
     public ApiResponse<List<ScheduleListResponse>> getDailySchedules(
             @AuthenticationPrincipal Long userId,
@@ -69,7 +74,8 @@ public class ScheduleController {
         return ApiResponse.onSuccess(response, SuccessCode.OK);
     }
 
-    // 특정 일정 조회 API
+    // 특정 일정 상세 조회 API
+    @Operation(summary = "특정 일정 상세 조회 API",description = "특정 일정에 대한 정보 조회")
     @GetMapping("/{scheduleId}")
     public ApiResponse<ScheduleDetailResponse> getScheduleDetail(
             @AuthenticationPrincipal Long userId,
@@ -80,6 +86,7 @@ public class ScheduleController {
     }
 
     // 일정 수정 API
+    @Operation(summary = "일정 수정 API",description = "수정된 정보 저장")
     @PutMapping("/{scheduleId}")
     public ApiResponse<String> updateSchedule(
             @AuthenticationPrincipal Long userId,


### PR DESCRIPTION
## 📄 작업 내용 요약
자주 가는 장소 등록(ai 추론 여부 포함),내 장소 리스트 가져오기 구현
-> ai 추론 여부를 favoriteplacestandard 엔티티에 추가, 기존 온보딩&자주가는장소 등록 api 에서는 false 로 저장되도록 설정
컨트롤러 설명 설정

<img width="1431" height="1445" alt="스크린샷 2026-01-31 015622" src="https://github.com/user-attachments/assets/0aa09db6-362d-48da-849f-5324224ecb04" />
<img width="1439" height="1439" alt="스크린샷 2026-01-31 015642" src="https://github.com/user-attachments/assets/f32977e7-52d1-4003-b85e-df408a2b5b96" />
자주 가는 장소에 추가 후, "isFavoriteRecommendation" 변환 확인

---

## 📎 Issue 번호

- closed #87 

---

## ✅ 작업 목록

- [x] 기능 구현
- [ ] 코드 리뷰 반영

---