### PR TITLE
[Feat] 할 일 일자별 목록 조회 구현

### DIFF
--- a/src/main/java/app/tamingo/domain/todo/controller/TodoController.java
+++ b/src/main/java/app/tamingo/domain/todo/controller/TodoController.java
@@ -9,8 +9,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @RestController
 @RequiredArgsConstructor
@@ -80,6 +83,16 @@ public class TodoController {
             @Valid @RequestBody RecommendScheduleRequest request
     ) {
         RecommendScheduleResponse response = todoService.recommendSchedules(userId, request);
+        return ApiResponse.onSuccess(response, SuccessCode.OK);
+    }
+
+    @Operation(summary = "날짜별 할 일 목록 조회 API", description = "특정 날짜의 할 일(완료 포함)과 날짜 미지정 할 일(미완료만)을 함께 조회합니다. 카테고리별로 정렬되어 반환됩니다.")
+    @GetMapping
+    public ApiResponse<DailyTodoListResponse> getDailyTodos(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date
+    ) {
+        DailyTodoListResponse response = todoService.getDailyTodos(userId, date);
         return ApiResponse.onSuccess(response, SuccessCode.OK);
     }
 }

--- a/src/main/java/app/tamingo/domain/todo/dto/DailyTodoListResponse.java
+++ b/src/main/java/app/tamingo/domain/todo/dto/DailyTodoListResponse.java
@@ -1,0 +1,15 @@
+package app.tamingo.domain.todo.dto;
+
+import java.util.List;
+
+public record DailyTodoListResponse(
+        List<TodoListResponse> dailyTodos,
+        List<TodoListResponse> backlogTodos
+) {
+    public static DailyTodoListResponse of(
+            List<TodoListResponse> dailyTodos,
+            List<TodoListResponse> backlogTodos
+    ) {
+        return new DailyTodoListResponse(dailyTodos, backlogTodos);
+    }
+}

--- a/src/main/java/app/tamingo/domain/todo/dto/TodoListResponse.java
+++ b/src/main/java/app/tamingo/domain/todo/dto/TodoListResponse.java
@@ -1,0 +1,27 @@
+package app.tamingo.domain.todo.dto;
+
+import app.tamingo.domain.todo.entity.Todo;
+import app.tamingo.domain.todo.entity.TodoCategory;
+
+public record TodoListResponse(
+        Long todoId,
+        String title,
+        String categoryName,
+        String categoryColor,
+        boolean isChecked
+) {
+    public static TodoListResponse from(Todo todo) {
+        TodoCategory category = todo.getTodoCategory();
+
+        String name = (category != null) ? category.getName() : null;
+        String color = (category != null) ? category.getColorCode() : null;
+
+        return new TodoListResponse(
+                todo.getId(),
+                todo.getTitle(),
+                name,
+                color,
+                todo.isChecked()
+        );
+    }
+}

--- a/src/main/java/app/tamingo/domain/todo/entity/Todo.java
+++ b/src/main/java/app/tamingo/domain/todo/entity/Todo.java
@@ -187,6 +187,10 @@ public class Todo extends BaseEntity {
         this.isChecked = isChecked;
     }
 
+    public void updateTargetDate(LocalDate targetDate) {
+        this.targetDate = targetDate;
+    }
+
     // 반복 할 일 생성용
     public static Todo createRecurring(
             User user,

--- a/src/main/java/app/tamingo/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/app/tamingo/domain/todo/repository/TodoRepository.java
@@ -89,4 +89,29 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
     List<Todo> findAllByScheduleAndLocation(@Param("schedule") Schedule schedule);
 
     List<Todo> findAllBySchedule(@Param("schedule") Schedule schedule);
+
+    // 날짜 지정 할 일 조회 (Daily)
+    @Query("""
+        SELECT t FROM Todo t 
+        LEFT JOIN FETCH t.todoCategory 
+        WHERE t.user.id = :userId 
+        AND t.targetDate = :date 
+        ORDER BY t.id ASC
+    """)
+    List<Todo> findDailyTodos(
+            @Param("userId") Long userId,
+            @Param("date") LocalDate date
+    );
+
+    // 날짜 미지정 할 일 조회 (Backlog)
+    @Query("""
+        SELECT t FROM Todo t 
+        LEFT JOIN FETCH t.todoCategory 
+        WHERE t.user.id = :userId 
+        AND t.targetDate IS NULL 
+        AND t.isChecked = false 
+        ORDER BY t.id ASC
+    """)
+    List<Todo> findBacklogTodos(@Param("userId") Long userId);
+
 }

--- a/src/main/java/app/tamingo/domain/todo/service/TodoService.java
+++ b/src/main/java/app/tamingo/domain/todo/service/TodoService.java
@@ -291,6 +291,10 @@ public class TodoService {
             throw new CustomException(TodoErrorCode.TODO_NOT_OWNER);
         }
 
+        if (isChecked && todo.getTargetDate() == null) {
+            todo.updateTargetDate(LocalDate.now());
+        }
+
         // 상태 변경
         todo.updateCheckStatus(isChecked);
     }
@@ -364,6 +368,30 @@ public class TodoService {
                 today.atStartOfDay(),
                 today.plusDays(7).atTime(23, 59, 59)
         );
+    }
+
+    /**
+     * 날짜 지정 + 미지정 할 일 조회
+     */
+    public DailyTodoListResponse getDailyTodos(Long userId, LocalDate date) {
+
+        if (!userRepository.existsById(userId)) {
+            throw new CustomException(UserErrorCode.USER_NOT_FOUND);
+        }
+
+        // 해당 날짜 할 일 조회 (카테고리 정렬)
+        List<TodoListResponse> dailyTodos = todoRepository.findDailyTodos(userId, date)
+                .stream()
+                .map(TodoListResponse::from)
+                .toList();
+
+        // 날짜 미지정 할 일 조회 (미완료만)
+        List<TodoListResponse> backlogTodos = todoRepository.findBacklogTodos(userId)
+                .stream()
+                .map(TodoListResponse::from)
+                .toList();
+
+        return DailyTodoListResponse.of(dailyTodos, backlogTodos);
     }
 
 }


### PR DESCRIPTION
## 📄 작업 내용 요약

- 할 일 일자별 목록 조회 구현
  - 날짜 지정, 미지정 나눠서 반환
  - 생성 순으로 반환
  - 카테고리 색상 코드도 포함해서 반환
  - 날짜 미지정 할 일 체크 시, 누른 당일로 날짜 강제 변경

---

## 📎 Issue 번호
- closed #144 

---

## ✅ 작업 목록

- [x] 기능 구현
- [ ] 코드 리뷰 반영

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->